### PR TITLE
Enable parallel SIP call handling

### DIFF
--- a/llm/live_call/groq_agent.py
+++ b/llm/live_call/groq_agent.py
@@ -6,7 +6,6 @@ from typing import List, Dict, Any, Optional
 
 from groq import Groq
 from crm.crm_api import load_enriched_funnel_config
-from sip.utils import get_active_lead_id
 from tts.elevenlabs_tts import text_to_speech_async
 
 logging.basicConfig(level=logging.INFO)
@@ -106,11 +105,10 @@ class GroqAgent:
         
         return groq_messages
 
-    async def process_async(self, user_text: str) -> str:
+    async def process_async(self, user_text: str, lead_id: Optional[str], call=None) -> str:
         if self.llm_busy:
             return "[GROQ] Пожалуйста, дождитесь ответа на предыдущий вопрос."
         
-        lead_id = get_active_lead_id()
         if not lead_id:
             logging.warning("[GROQ] Не удалось получить ID активного лида")
         
@@ -132,7 +130,7 @@ class GroqAgent:
                     full_reply = response.choices[0].message.content
                     
                     # Отправляем реплику в TTS и на воспроизведение
-                    self._send_to_tts_and_play(full_reply)
+                    self._send_to_tts_and_play(full_reply, call)
                     
                     history.append({"role": "assistant", "content": full_reply})
                     self._save_history(lead_id, history)
@@ -155,26 +153,26 @@ class GroqAgent:
         log_lines.append("========== КОНЕЦ ИСТОРИИ ==========")
         logging.info("\n".join(log_lines))
 
-    def _send_to_tts_and_play(self, text: str) -> None:
+    def _send_to_tts_and_play(self, text: str, call=None) -> None:
         """
         Отправляет текст в TTS и добавляет аудиофайл в очередь для воспроизведения
         """
         logging.info(f"[GROQ->TTS] Отправляем в TTS: {text}")
         
         def tts_callback(audio_filepath: Optional[str]) -> None:
-            if audio_filepath and os.path.exists(audio_filepath):
+            if audio_filepath and os.path.exists(audio_filepath) and call:
                 logging.info(f"[TTS] Аудиофайл готов: {audio_filepath}")
-                # Добавляем файл в очередь воспроизведения (безопасно из любого потока)
-                from sip.audio_player import queue_audio_for_playback
-                queue_audio_for_playback(audio_filepath)
-                logging.info(f"[TTS] Файл добавлен в очередь: {os.path.basename(audio_filepath)}")
-            else:
+                call.queue_audio_file(audio_filepath)
+                logging.info(
+                    f"[TTS] Файл добавлен в очередь: {os.path.basename(audio_filepath)}"
+                )
+            elif not audio_filepath:
                 logging.error("[TTS] Не удалось создать аудиофайл")
         
         # Асинхронно создаем аудио и добавляем в очередь
         text_to_speech_async(text, tts_callback)
 
-    def process(self, user_text: str):
+    def process(self, user_text: str, lead_id: Optional[str], call=None):
         loop = None
         try:
             loop = asyncio.get_running_loop()
@@ -182,9 +180,9 @@ class GroqAgent:
             pass
             
         if loop and loop.is_running():
-            return asyncio.create_task(self.process_async(user_text))
+            return asyncio.create_task(self.process_async(user_text, lead_id, call))
         else:
-            return asyncio.run(self.process_async(user_text))
+            return asyncio.run(self.process_async(user_text, lead_id, call))
 
 
 # Глобальные функции для совместимости
@@ -197,12 +195,12 @@ def get_llm_agent():
         _llm_agent_instance = GroqAgent()
     return _llm_agent_instance
 
-async def process_transcript_async(transcript: str) -> str:
+async def process_transcript_async(transcript: str, lead_id: Optional[str], call=None) -> str:
     """Асинхронная обработка транскрипта"""
     agent = get_llm_agent()
-    return await agent.process_async(transcript)
+    return await agent.process_async(transcript, lead_id, call)
 
-def process_transcript(transcript: str):
+def process_transcript(transcript: str, lead_id: Optional[str], call=None):
     """Синхронная обработка транскрипта"""
     loop = None
     try:
@@ -211,6 +209,6 @@ def process_transcript(transcript: str):
         pass
         
     if loop and loop.is_running():
-        return asyncio.create_task(process_transcript_async(transcript))
+        return asyncio.create_task(process_transcript_async(transcript, lead_id, call))
     else:
-        return asyncio.run(process_transcript_async(transcript))
+        return asyncio.run(process_transcript_async(transcript, lead_id, call))

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ def main():
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     config = load_config()
     sip_event_queue = queue.Queue()
-    sip_event_queue.current_call = None  # текущий звонок
     sip_event_queue.config = config
     
     ep = None
@@ -38,15 +37,12 @@ def main():
         import time
         while True:
             try:
-                if hasattr(sip_event_queue, 'current_call') and sip_event_queue.current_call:
-                    from sip.audio_player import process_audio_queue
-                    process_audio_queue()
-                    
-                    # Проверяем отложенное воспроизведение аудио в текущем звонке
-                    sip_event_queue.current_call.check_pending_audio()
+                for call in list(acc.active_calls.values()):
+                    call.process_audio_queue()
+                    call.check_pending_audio()
             except queue.Empty:
                 pass
-            except Exception as e:
+            except Exception:
                 pass
             time.sleep(0.05)
 

--- a/sip/account.py
+++ b/sip/account.py
@@ -27,6 +27,7 @@ class Account(pj.Account):
         self.sip_event_queue = sip_event_queue
         self.transcript_queue = transcript_queue
         self.sem_reg = threading.Semaphore(0)
+        self.active_calls = {}
 
     def onRegState(self, prm):
         print(f"[PJSUA] Статус регистрации: {prm.reason}")
@@ -37,7 +38,7 @@ class Account(pj.Account):
         print("[PJSUA] Входящий звонок...")
         call_id = str(uuid.uuid4())
         call = Call(self, prm.callId)
-        self.sip_event_queue.current_call = call
+        self.active_calls[prm.callId] = call
 
         from llm.live_call.groq_agent import get_llm_agent
         get_llm_agent()
@@ -104,5 +105,3 @@ class Account(pj.Account):
                 time.sleep(0.05)
             call.start_audio_streaming(0)
         threading.Thread(target=start_streaming_after_answer, daemon=True).start()
-
-_active_lead_id = None

--- a/sip/audio_player.py
+++ b/sip/audio_player.py
@@ -8,100 +8,63 @@
 import os
 import logging
 import queue
-import threading
 from .call import Call
 
-# Глобальная очередь для безопасной передачи аудиофайлов между потоками
-_audio_queue = queue.Queue()
-_queue_lock = threading.Lock()
 
-
-def queue_audio_for_playback(audio_file_path):
-    """
-    Добавляет аудиофайл в очередь для воспроизведения.
-    Безопасно вызывать из любого потока.
-    
-    Args:
-        audio_file_path (str): Путь к аудиофайлу
-    """
+def queue_audio_for_playback(call: Call, audio_file_path: str):
+    """Добавляет аудиофайл в очередь конкретного звонка."""
     try:
-        _audio_queue.put(audio_file_path, block=False)
-        logging.info(f"[AUDIO] Файл добавлен в очередь: {os.path.basename(audio_file_path)}")
+        call.audio_queue.put(audio_file_path, block=False)
+        logging.info(
+            f"[AUDIO] Файл добавлен в очередь: {os.path.basename(audio_file_path)}"
+        )
     except queue.Full:
         logging.error("[AUDIO] Очередь воспроизведения переполнена")
 
 
-def process_audio_queue():
-    """
-    Обрабатывает очередь аудиофайлов для воспроизведения.
-    ДОЛЖНА вызываться только из основного потока PJSUA!
-    
-    Returns:
-        bool: True если был обработан хотя бы один файл
-    """
+def process_audio_queue(call: Call):
+    """Обрабатывает очередь аудиофайлов конкретного звонка."""
     processed = False
-    
+
     try:
-        while not _audio_queue.empty():
+        while not call.audio_queue.empty():
             try:
-                audio_file_path = _audio_queue.get_nowait()
-                success = play_audio_to_current_call(audio_file_path)
+                audio_file_path = call.audio_queue.get_nowait()
+                success = call.play_audio_file(audio_file_path)
                 if success:
-                    logging.info(f"[AUDIO] Воспроизведение началось: {os.path.basename(audio_file_path)}")
+                    logging.info(
+                        f"[AUDIO] Воспроизведение началось: {os.path.basename(audio_file_path)}"
+                    )
                     processed = True
                 else:
-                    logging.error(f"[AUDIO] Не удалось воспроизвести: {audio_file_path}")
-                _audio_queue.task_done()
+                    logging.error(
+                        f"[AUDIO] Не удалось воспроизвести: {audio_file_path}"
+                    )
+                call.audio_queue.task_done()
             except queue.Empty:
                 break
     except Exception as e:
         logging.error(f"[AUDIO] Ошибка при обработке очереди: {e}")
-    
+
     return processed
 
 
-def play_audio_to_current_call(audio_file_path, loop=False):
-    """
-    Воспроизводит аудиофайл в текущий активный звонок.
-    
-    Args:
-        audio_file_path (str): Путь к аудиофайлу
-        loop (bool): Зацикливать ли воспроизведение
-        
-    Returns:
-        bool: True если воспроизведение началось успешно, False в противном случае
-    """
-    current_call = Call.current
-    if not current_call:
-        logging.warning("[AUDIO] Нет активного звонка для воспроизведения аудио")
-        return False
-        
-    return current_call.play_audio_file(audio_file_path, loop)
+def play_audio_to_call(call: Call, audio_file_path: str, loop: bool = False) -> bool:
+    """Воспроизводит аудиофайл в указанный звонок."""
+    return call.play_audio_file(audio_file_path, loop)
 
 
-def stop_current_call_audio():
-    """
-    Останавливает воспроизведение аудио в текущем активном звонке.
-    
-    Returns:
-        bool: True если остановка прошла успешно, False в противном случае
-    """
-    current_call = Call.current
-    if not current_call:
-        return True
-        
-    return current_call.stop_audio_playback()
+def stop_call_audio(call: Call) -> bool:
+    """Останавливает воспроизведение аудио в указанном звонке."""
+    return call.stop_audio_playback()
 
 
-def play_welcome_message():
-    """
-    Воспроизводит приветственное сообщение в текущий звонок.
-    
-    Returns:
-        bool: True если воспроизведение началось успешно, False в противном случае
-    """
-    welcome_file = os.path.join(os.path.dirname(__file__), '..', 'ElevenLabs_Text_to_Speech_audio.wav')
-    return play_audio_to_current_call(welcome_file)
+def play_welcome_message(call: Call) -> bool:
+    """Воспроизводит приветственное сообщение в указанный звонок."""
+    welcome_file = os.path.join(
+        os.path.dirname(__file__), "..", "ElevenLabs_Text_to_Speech_audio.wav"
+    )
+    return play_audio_to_call(call, welcome_file)
 
 
 def get_audio_file_path(filename):

--- a/sip/call.py
+++ b/sip/call.py
@@ -2,6 +2,7 @@ import threading
 import os
 import time
 import wave
+import queue
 import pjsua2 as pj
 from stt.deepgram_stt import DeepgramSTTSession
 
@@ -23,7 +24,7 @@ class Call(pj.Call):
         self._player_start_time = 0
         self._max_playback_duration = 30
         self._current_audio_duration = 0  # Длительность текущего файла
-        Call.current = self
+        self.audio_queue = queue.Queue()
 
     def onCallState(self, prm):
         ci = self.getInfo()
@@ -63,9 +64,8 @@ class Call(pj.Call):
                         self._current_audio_duration = 0
             except Exception as e:
                 print(f"[PJSUA] Ошибка при освобождении медиа ресурсов: {e}")
-            if hasattr(self.acc.sip_event_queue, 'current_call'):
-                self.acc.sip_event_queue.current_call = None
-            Call.current = None
+            if hasattr(self.acc, 'active_calls'):
+                self.acc.active_calls.pop(self.getId(), None)
             if self._stt_session:
                 self._stt_session.close()
             
@@ -95,7 +95,7 @@ class Call(pj.Call):
 
     def connect_stt_session(self, filename):
         self._recording_filename = filename
-        self._stt_session = DeepgramSTTSession(filename)
+        self._stt_session = DeepgramSTTSession(filename, call=self)
         self._stt_session.connect()
 
     def _get_audio_duration(self, audio_file_path):
@@ -209,6 +209,30 @@ class Call(pj.Call):
             self._player_start_time = 0
             self._current_audio_duration = 0
             return False
+
+    def queue_audio_file(self, audio_file_path):
+        try:
+            self.audio_queue.put(audio_file_path, block=False)
+        except queue.Full:
+            print("[AUDIO] Очередь воспроизведения переполнена")
+
+    def process_audio_queue(self):
+        processed = False
+        try:
+            while not self.audio_queue.empty():
+                try:
+                    audio_file_path = self.audio_queue.get_nowait()
+                    success = self.play_audio_file(audio_file_path)
+                    if success:
+                        processed = True
+                    else:
+                        print(f"[AUDIO] Не удалось воспроизвести: {audio_file_path}")
+                    self.audio_queue.task_done()
+                except queue.Empty:
+                    break
+        except Exception as e:
+            print(f"[AUDIO] Ошибка при обработке очереди: {e}")
+        return processed
 
     def start_audio_streaming(self, media_index):
         if self.audio_streaming:

--- a/sip/utils.py
+++ b/sip/utils.py
@@ -1,5 +1,4 @@
-def get_active_lead_id():
-    """Возвращает ID текущей активной сделки из очереди событий"""
-    import sip.call
-    if sip.call.Call.current and hasattr(sip.call.Call.current.acc.sip_event_queue, 'config'):
-        return sip.call.Call.current.acc.sip_event_queue.config.get('ACTIVE_LEAD_ID') 
+def get_active_lead_id(call=None):
+    """Возвращает ID текущей активной сделки"""
+    if call and hasattr(call.acc.sip_event_queue, 'config'):
+        return call.acc.sip_event_queue.config.get('ACTIVE_LEAD_ID')

--- a/stt/deepgram_stt.py
+++ b/stt/deepgram_stt.py
@@ -34,8 +34,9 @@ if not DEEPGRAM_API_KEY:
     exit(1)
 
 class DeepgramSTTSession:
-    def __init__(self, wav_file):
+    def __init__(self, wav_file, call=None):
         self.wav_file = wav_file
+        self.call = call
         self.ws = None
         self.stop_event = threading.Event()
         self.loop = None
@@ -110,12 +111,19 @@ class DeepgramSTTSession:
                                 except RuntimeError:
                                     loop = None
                                 if loop and loop.is_running():
-                                    fut = asyncio.run_coroutine_threadsafe(process_transcript_async(full_text), loop)
+                                    fut = asyncio.run_coroutine_threadsafe(
+                                        process_transcript_async(full_text, getattr(self.call, 'lead_id', None), self.call),
+                                        loop,
+                                    )
                                     llm_response = fut.result()
                                 else:
-                                    llm_response = asyncio.run(process_transcript_async(full_text))
+                                    llm_response = asyncio.run(
+                                        process_transcript_async(full_text, getattr(self.call, 'lead_id', None), self.call)
+                                    )
                             else:
-                                llm_response = process_transcript(full_text)
+                                llm_response = process_transcript(
+                                    full_text, getattr(self.call, 'lead_id', None), self.call
+                                )
                         except Exception as e:
                             llm_response = f"[LLM] Ошибка: {e}"
                         delay_ms = None


### PR DESCRIPTION
## Summary
- support multiple concurrent calls via active call tracking
- use per-call audio queues and playback helpers
- connect STT and LLM processing to specific calls
- update main loop to iterate over active calls

## Testing
- `python -m py_compile main.py sip/*.py llm/live_call/groq_agent.py stt/deepgram_stt.py`

------
https://chatgpt.com/codex/tasks/task_e_6864646f5d708329832f47c3db2f852b